### PR TITLE
Fixes a rare issue that caused severe CPU usage increase.

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -414,7 +414,13 @@ namespace xiloader
             struct sockaddr_in client;
             unsigned int socksize = sizeof(client);
             if (recvfrom(sock->s, recvBuffer, sizeof(recvBuffer), 0, (struct sockaddr*)&client, (int*)&socksize) <= 0)
+            {
+                if (WSAGetLastError() == 0)
+                {
+                    Sleep(100);
+                }
                 continue;
+            }
 
             switch (recvBuffer[0])
             {


### PR DESCRIPTION
Under some conditions, this recvfrom call would immediately error with a WSAGetLastError value of 0 when no data was waiting.  This would cause the call to occur over and over, saturating a cpu thread.  This issue has been present since at least 2019, observed here:
https://na.nasomi.com/forum/viewtopic.php?f=14&t=9159

I examined the code and personally concluded that this was the most likely cause by looking for places that would potentially loop infinitely.  I rebuilt the bootloader with several debug outputs, and worked with discord user TheJapolian#3987, who was suffering from the issue on current branch of horizon.  This allowed me to verify that this was indeed the source of the CPU usage and the last error code in this case was 0.  I rebuilt the bootloader with this fix in place, and verified that his issue was resolved.

This error code is not documented, so I am unsure of the underlying cause, or why it only effects a very small subset of users.  It is possible this same issue could occur in other circumstances, so if any user presents with the same symptoms after this fix is in place, I recommend removing the error code check and simply sleeping any time the recvfrom call fails.