### PR TITLE
Backport LSB useful xiloader changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,9 @@ add_executable(xiloader
     src/main.cpp
     src/network.cpp
     src/network.h
-    src/polcore.h)
+    src/polcore.h
+    xiloader.manifest
+)
 
 set_target_properties(xiloader PROPERTIES LINK_FLAGS "/LARGEADDRESSAWARE")
 

--- a/cmake/mbedtls.cmake
+++ b/cmake/mbedtls.cmake
@@ -1,7 +1,7 @@
 CPMAddPackage(
   NAME mbedtls
   GITHUB_REPOSITORY Mbed-TLS/mbedtls
-  GIT_TAG 1873d3bfc2da771672bd8e7e8f41f57e0af77f33
+  GIT_TAG mbedtls-3.6.2
   OPTIONS
     "ENABLE_PROGRAMS OFF"
     "ENABLE_TESTING OFF"

--- a/src/console.h
+++ b/src/console.h
@@ -90,6 +90,8 @@ namespace xiloader
          */
         static void visible(bool visible);
 
+        public:
+
         /**
          * @brief Prints a text fragment with the specified color to the console.
          * 
@@ -97,8 +99,6 @@ namespace xiloader
          * @param message   The fragment to print.
          */
         static void print(xiloader::color c, std::string const& message);
-
-    public:
 
         /**
          * @brief Prints the given message to the console.
@@ -112,15 +112,7 @@ namespace xiloader
             output(xiloader::color::white, format, args...);
         }
 
-        /**
-         * @brief Prints the given message to the console with the specific color.
-         *
-         * @param c         The color to print the message with.
-         * @param format    The format of the message to print.
-         * @param args      The arguments to fill the format.
-         */
-        template<typename... Args>
-        static void output(xiloader::color c, char const* format, Args... args)
+        static std::string getTimestamp()
         {
             /* Get the current timestamp */
             ::__time32_t rawtime;
@@ -133,8 +125,23 @@ namespace xiloader
             char timestamp[256];
             ::strftime(timestamp, sizeof timestamp, "[%m/%d/%y %H:%M:%S] ", &timeinfo);
 
+            return timestamp;
+        }
+
+        /**
+         * @brief Prints the given message to the console with the specific color.
+         *
+         * @param c         The color to print the message with.
+         * @param format    The format of the message to print.
+         * @param args      The arguments to fill the format.
+         */
+        template<typename... Args>
+        static void output(xiloader::color c, char const* format, Args... args)
+        {
+            std::string timestamp = getTimestamp();
+
             /* Output the timestamp */
-            print(xiloader::color::lightyelllow, timestamp);
+            print(xiloader::color::lightyelllow, timestamp.c_str());
 
             /* Parse the incoming message */
             char buffer[1024];

--- a/xiloader.manifest
+++ b/xiloader.manifest
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+	<!-- https://stackoverflow.com/a/44009779, set PerMonitorV2 -->
+	<!-- https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process -->
+    <asmv3:application>
+        <asmv3:windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware> <!-- fallback for Windows 7 and 8 -->
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness> <!-- adding v1 as fallback would result in v2 not being applied to dialogs on capable systems -->
+        </asmv3:windowsSettings>
+    </asmv3:application>
+</assembly>


### PR DESCRIPTION
Backport LSB useful xiloader changes
Main ones of concern:
Attempt to notify windows process is DPI aware (FFXI doesnt handle DPI scaling well)
Remove pointless warning about certificates not being valid
Fix search sometimes not working due to shenanigans