### PR TITLE
Changes exe filename to what we actually use, updates version number.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ add_executable(xiloader
     xiloader.manifest
 )
 
+set_target_properties(xiloader PROPERTIES OUTPUT_NAME "horizon-loader")
+
 set_target_properties(xiloader PROPERTIES LINK_FLAGS "/LARGEADDRESSAWARE")
 
 target_include_directories(xiloader PUBLIC ${PROJECT_SOURCE_DIR}/xiloader)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,7 +46,7 @@ namespace globals
     std::string        g_Password        = "";                          // The password being logged in with.
     char               g_SessionHash[16] = {};                          // Session hash sent from auth
     std::string        g_Email           = "";                          // Email, currently unused
-    std::string        g_VersionNumber   = "1.0.0";                     // xiloader version number sent to auth server. Must be x.x.x with single characters for 'x'
+    std::string        g_VersionNumber   = "1.1.4";                     // xiloader version number sent to auth server. Must be x.x.x with single characters for 'x'
     bool               g_FirstLogin      = false;                       // set to true when --user --pass are both set to allow for autologin
 
     char* g_CharacterList = NULL;  // Pointer to the character list data being sent from the server.


### PR DESCRIPTION
Compiler was still outputting `xiloader.exe`. This changes it to `horizon-loader.exe` which is what we ship with our client.

Also updates the version number to match LSB's xiloader.